### PR TITLE
ensure python booleans can be accepted as set parameters without manual conversion by the user

### DIFF
--- a/pyamaha/__init__.py
+++ b/pyamaha/__init__.py
@@ -306,7 +306,7 @@ class System():
         Arguments:
         enable -- Specifies Auto Power Standby status.
         """
-        return System.URI['SET_AUTOPOWER_STANDBY'].format(host='{host}', enable=enable)
+        return System.URI['SET_AUTOPOWER_STANDBY'].format(host='{host}', enable=_bool_to_str(enable))
     # end-of-method set_autopower_standby
 
     @staticmethod
@@ -512,13 +512,13 @@ class System():
     @staticmethod
     def set_bluetooth_standby(enable=True):
         """For setting Bluetooth Standby"""
-        return System.URI['SET_BLUETOOTH_STANDBY'].format(host='{host}', enable=enable)
+        return System.URI['SET_BLUETOOTH_STANDBY'].format(host='{host}', enable=_bool_to_str(enable))
     # end-of-method set_bluetooth_standby
     
     @staticmethod
     def set_bluetooth_tx_setting(enable=True):
         """For setting Bluetooth transmission"""
-        return System.URI['SET_BLUETOOTH_TX_SETTING'].format(host='{host}', enable=enable)
+        return System.URI['SET_BLUETOOTH_TX_SETTING'].format(host='{host}', enable=_bool_to_str(enable))
     # end-of-method set_bluetooth_tx_setting
 
     @staticmethod
@@ -562,13 +562,13 @@ class System():
     @staticmethod
     def set_speaker_a(enable=True):
         """For setting Speaker A status"""
-        return System.URI['SET_SPEAKER_A'].format(host='{host}', enable=enable)
+        return System.URI['SET_SPEAKER_A'].format(host='{host}', enable=_bool_to_str(enable))
     # end-of-method set_speaker_a
     
     @staticmethod
     def set_speaker_b(enable=True):
         """For setting Speaker A status"""
-        return System.URI['SET_SPEAKER_B'].format(host='{host}', enable=enable)
+        return System.URI['SET_SPEAKER_B'].format(host='{host}', enable=_bool_to_str(enable))
     # end-of-method set_speaker_b
     
     @staticmethod
@@ -589,19 +589,19 @@ class System():
     @staticmethod
     def set_zone_b_volume_sync(enable):
         """For setting Zone B volume sync."""
-        return System.URI['SET_ZONE_B_VOLUME_SYNC'].format(host='{host}', enable=enable)
+        return System.URI['SET_ZONE_B_VOLUME_SYNC'].format(host='{host}', enable=_bool_to_str(enable))
     # end-of-method set_zone_b_volume_sync
     
     @staticmethod
     def set_hdmi_out_1(enable):
         """set_hdmi_out_1."""
-        return System.URI['SET_HDMI_OUT_1'].format(host='{host}', enable=enable)
+        return System.URI['SET_HDMI_OUT_1'].format(host='{host}', enable=_bool_to_str(enable))
     # end-of-method set_hdmi_out_1
     
     @staticmethod
     def set_hdmi_out_2(enable):
         """set_hdmi_out_1."""
-        return System.URI['SET_HDMI_OUT_2'].format(host='{host}', enable=enable)
+        return System.URI['SET_HDMI_OUT_2'].format(host='{host}', enable=_bool_to_str(enable))
     # end-of-method set_hdmi_out_2
     
     @staticmethod
@@ -757,7 +757,7 @@ class Zone():
             enable -- Specifying mute status. Default: True.
         """
         assert zone in ZONES, 'Invalid ZONE value!'
-        return Zone.URI['SET_MUTE'].format(host='{host}', zone=zone, enable=enable)
+        return Zone.URI['SET_MUTE'].format(host='{host}', zone=zone, enable=_bool_to_str(enable))
     # end-of-method set_mute
     
     @staticmethod
@@ -815,7 +815,7 @@ class Zone():
             enable -- Specifies 3D Surround status.
         """
         assert zone in ZONES, 'Invalid ZONE value!'
-        return Zone.URI['SET_3D_SURROUND'].format(host='{host}', zone=zone, enable=enable)
+        return Zone.URI['SET_3D_SURROUND'].format(host='{host}', zone=zone, enable=_bool_to_str(enable))
     # end-of-method set_3d_surround
     
     @staticmethod
@@ -828,7 +828,7 @@ class Zone():
             enable -- Specifies Direct status.
         """
         assert zone in ZONES, 'Invalid ZONE value!'
-        return Zone.URI['SET_DIRECT'].format(host='{host}', zone=zone, enable=enable)
+        return Zone.URI['SET_DIRECT'].format(host='{host}', zone=zone, enable=_bool_to_str(enable))
     # end-of-method set_direct
     
     @staticmethod
@@ -841,7 +841,7 @@ class Zone():
             enable -- Specifies Pure Direct status.
         """
         assert zone in ZONES, 'Invalid ZONE value!'
-        return Zone.URI['SET_PURE_DIRECT'].format(host='{host}', zone=zone, enable=enable)
+        return Zone.URI['SET_PURE_DIRECT'].format(host='{host}', zone=zone, enable=_bool_to_str(enable))
     # end-of-method set_pure_direct
     
     @staticmethod
@@ -854,7 +854,7 @@ class Zone():
             enable -- Specifies Enhancer status.
         """
         assert zone in ZONES, 'Invalid ZONE value!'
-        return Zone.URI['SET_ENHANCER'].format(host='{host}', zone=zone, enable=enable)
+        return Zone.URI['SET_ENHANCER'].format(host='{host}', zone=zone, enable=_bool_to_str(enable))
     # end-of-method set_enhancer
     
     @staticmethod
@@ -989,7 +989,7 @@ class Zone():
             enable -- Specifies Bass Extension setting
         """
         assert zone in ZONES, 'Invalid ZONE value!'
-        return Zone.URI['SET_BASS_EXTENSION'].format(host='{host}', zone=zone, enable=enable)    
+        return Zone.URI['SET_BASS_EXTENSION'].format(host='{host}', zone=zone, enable=_bool_to_str(enable))
     # end-of-method set_bass_extension
     
     @staticmethod
@@ -1414,7 +1414,9 @@ class Debug():
     
     pass
 # end-of-class Debug
-    
+
+def _bool_to_str(value):
+    return str(value).lower()
 
 if __name__ == '__main__':
     pass

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [metadata]
 description-file = README.md
+
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 setup(
   name = 'pyamaha',
   packages = ['pyamaha'],
@@ -21,4 +21,6 @@ setup(
   install_requires=[
     'requests',
   ],
+  setup_requires=["pytest-runner"],
+  tests_require=["pytest"],
 )

--- a/tests/test_bool_to_str.py
+++ b/tests/test_bool_to_str.py
@@ -1,0 +1,24 @@
+from unittest import TestCase
+
+from pyamaha import _bool_to_str
+
+
+class TestBoolToStr(TestCase):
+
+    def test_lower_case_false_is_unaffected(self):
+        self.assertEqual(_bool_to_str('false'), 'false')
+
+    def test_lower_case_true_is_unaffected(self):
+        self.assertEqual(_bool_to_str('true'), 'true')
+
+    def test_title_case_false_is_made_lower_case(self):
+        self.assertEqual(_bool_to_str('False'), 'false')
+
+    def test_title_case_true_is_made_lower_case(self):
+        self.assertEqual(_bool_to_str('True'), 'true')
+
+    def test_boolean_false_is_outputted_in_lower_case(self):
+        self.assertEqual(_bool_to_str(False), 'false')
+
+    def test_boolean_true_is_outputted_in_lower_case(self):
+        self.assertEqual(_bool_to_str(True), 'true')

--- a/tests/test_set_mute.py
+++ b/tests/test_set_mute.py
@@ -1,0 +1,18 @@
+from unittest import TestCase
+
+from pyamaha import Zone, ZONES
+
+DEFAULT_ZONE = ZONES[0]
+
+
+class TestSetMute(TestCase):
+    expected = Zone.URI['SET_MUTE'].format(host='{host}', zone=DEFAULT_ZONE, enable='false')
+
+    def test_lower_case_strings_are_unaffected(self):
+        self.assertEqual(Zone.set_mute(DEFAULT_ZONE, 'false'), self.expected)
+
+    def test_title_case_strings_are_made_lower_case(self):
+        self.assertEqual(Zone.set_mute(DEFAULT_ZONE, 'False'), self.expected)
+
+    def booleans_are_outputted_in_lower_case(self):
+        self.assertEqual(Zone.set_mute(DEFAULT_ZONE, False), self.expected)


### PR DESCRIPTION
Issue found with title-cased values not being accepted:
http://192.168.1.1/YamahaExtendedControl/v1/main/setMute?enable=True

Propose lower-casing in prior to string formatting of boolean values.

Please run `python setup.py test` to check unit tests.