### PR TITLE
build using Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+dist: bionic   # required for Python >= 3.7
+language: python
+python:
+  - "2.7"
+  - "3.6"
+  - "3.6-dev"  # 3.6 development branch
+  - "3.7"
+  - "3.7-dev"  # 3.7 development branch
+  - "3.8-dev"  # 3.8 development branch
+  - "nightly"  # nightly build
+script:
+  - pytest

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![PyPI](https://img.shields.io/pypi/v/pyamaha.svg)](https://pypi.python.org/pypi/pyamaha)
 [![Join the chat at https://gitter.im/rsc-dev/pyamaha](https://badges.gitter.im/rsc-dev/pyamaha.svg)](https://gitter.im/rsc-dev/pyamaha?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status](https://travis-ci.org/rsc-dev/pyamaha.svg?branch=master)](https://travis-ci.org/rsc-dev/pyamaha)
 
 ## About
 Pyamaha is Python implementation of [Yamaha Extended Control API Specification](https://github.com/rsc-dev/pyamaha/blob/master/doc/YXC_API_Spec_Basic.pdf).
@@ -128,7 +129,7 @@ yxc\system>
         <td>x</td>
         <td>-</td>
         <td>Documented</td>
-    </tr> 
+    </tr>
     <tr>
         <td>/YamahaExtendedControl/v1/system/setAirPlayPin</td>
         <td>x</td>
@@ -170,7 +171,7 @@ yxc\system>
         <td>x</td>
         <td>-</td>
         <td>Documented</td>
-    </tr> 
+    </tr>
     <tr>
         <td>/YamahaExtendedControl/v1/system/setBluetoothTxSetting</td>
         <td>x</td>
@@ -230,7 +231,7 @@ yxc\system>
         <td>x</td>
         <td>-</td>
         <td>Documented</td>
-    </tr> 
+    </tr>
     <tr>
         <td>/YamahaExtendedControl/v1/system/setHdmiOut2</td>
         <td>x</td>


### PR DESCRIPTION
Automated testing of various python versions based on this guide:
https://docs.travis-ci.com/user/languages/python/

Should if set up in the `rsc-dev` account result in builds such as the following:
https://travis-ci.org/AaronRobson/pyamaha/builds/567148684

Includes a readme badge to indicate success or failure.

Please forgive the irrelevant trailing whitespace removal, my editor removes them on its own.