### PR TITLE
Add async device support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ python setup.py install
 ```
 
 ## Usage
-### API
+### API (with [requests](https://requests.readthedocs.io/en/master/))
 ```python
 from pyamaha import Device, System
 
@@ -27,6 +27,40 @@ dev = Device('192.168.1.1')
 res = dev.request(System.get_device_info())
 
 print(res.json()) # JSON response
+```
+
+### Async API (with [aiohttp](https://docs.aiohttp.org/en/stable/client_reference.html))
+```python
+import asyncio
+import sys
+
+import aiohttp
+
+from pyamaha import AsyncDevice, System
+
+
+async def main():
+    async with aiohttp.ClientSession() as session:
+        dev = AsyncDevice(session, "192.168.1.1")
+        res = await dev.request(System.get_device_info())
+
+        v = await res.json()
+        print(v)
+
+
+# To avoid 'Event loop is closed' RuntimeError due to compatibility issue with aiohttp
+if sys.platform.startswith("win") and sys.version_info >= (3, 8):
+    try:
+        from asyncio import WindowsSelectorEventLoopPolicy
+    except ImportError:
+        pass
+    else:
+        if not isinstance(
+            asyncio.get_event_loop_policy(), WindowsSelectorEventLoopPolicy
+        ):
+            asyncio.set_event_loop_policy(WindowsSelectorEventLoopPolicy())
+asyncio.run(main())
+
 ```
 
 ### CLI

--- a/pyamaha/__init__.py
+++ b/pyamaha/__init__.py
@@ -107,6 +107,63 @@ class Device():
 # end-of-class Device    
 
 
+class AsyncDevice():
+    """
+    Yamaha async device abstraction class.
+    """
+    
+    def __init__(self, client, ip):
+        """Ctor.
+        
+        Arguments:
+            client -- aiohttp client session.
+            ip -- Yamaha device IP.
+        """
+        self.client = client
+        self.ip = ip
+
+        from aiohttp import ClientConnectorError, ClientResponse, ClientSession
+
+    # end-of-method __init__
+    
+    async def request(self, *args):
+        """Request YamahaExtendedControl API URI.
+        
+        Arguments:
+            args -- URI link for GET or tupple (URI, data) for POST.
+        """
+        
+        # If it is only a URI, send GET...
+        if isinstance(args[0], str):
+            return await self.get(args[0])
+        else:
+            # ...otherwise unpack tuple and send POST
+            return await self.post(*(args[0]))
+    # end-of-method request
+    
+    async def get(self, uri):
+        """Request given URI. Returns response object.
+        
+        Arguments:
+            uri -- URI to request
+        """
+        return await self.client.get(uri.format(host=self.ip))
+    # end-of-method get    
+    
+    async def post(self, uri, data):
+        """Send POST request. Returns response object.
+        
+        Arguments:
+            uri -- URI to send POST
+            data -- POST data
+        """
+        return await self.client.post(uri.format(host=self.ip), data=json.dumps(data))
+    # end-of-method post    
+    
+    pass
+# end-of-class Device    
+
+
 class Dist():
     """APIs in regard to Link distribution related setting and getting information."""
     

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+aiohttp

--- a/setup.py
+++ b/setup.py
@@ -23,4 +23,5 @@ setup(
   ],
   setup_requires=["pytest-runner"],
   tests_require=["pytest"],
+  extras_require={"async": ["aiohttp"]}
 )


### PR DESCRIPTION
I'm currently considering to use this library for the [MusicCast-Integration](https://www.home-assistant.io/integrations/yamaha_musiccast/) in [Home Assistant](https://www.home-assistant.io/). To do this properly, the communication to the MusicCast devices has to be async, that's why I added `AsyncDevice`.

I marked the dependency `aiohttp` as optional, so that people that need async functionality can install this via `pip install pyamaha[async]`.